### PR TITLE
refactor(UIKIT-676): Изменена типизация guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,7 +912,7 @@ type Values = { name: string; isAgree: boolean };
 
 const validate = object<Values, Values>({
   name: when({
-    is: (_, ctx) => ctx.global.values.isAgree,
+    is: (_, ctx) => Boolean(ctx.global.values.isAgree),
     then: string(),
     otherwise: any(),
   }),
@@ -966,7 +966,7 @@ type Values = {
   nickname: string;
 };
 
-const validate = object<Values>({
+const validate = object<Values, Values>({
   name: string(),
   nickname: string((value, ctx) => {
     if (value.includes('_')) {
@@ -998,7 +998,7 @@ type Values = {
 
 const validate = object<Values, Values>({
   password: string(min(9)),
-  repeatPassword: string<Values>(min(9), (value, ctx) => {
+  repeatPassword: string(min(9), (value, ctx) => {
     if (value !== ctx.global.values.password) {
       return ctx.createError({
         message: 'Пароли не совпадают',
@@ -1091,7 +1091,7 @@ type Values = { name: string; isAgree: boolean };
 
 const validate = object<Values, Values>({
   name: when({
-    is: (_, ctx) => ctx.global.values.isAgree,
+    is: (_, ctx) => Boolean(ctx.global.values.isAgree),
     then: string(),
     otherwise: any(),
   }),
@@ -1116,7 +1116,7 @@ type Values = {
 
 const validate = object<Values, Values>({
   name: string(),
-  info: when<Values>({
+  info: when({
     is: (_, ctx) => ctx.global.values.name === 'Vasya',
     then: object<ValuesInfo>({ surname: string() }),
     otherwise: any(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "validations",
+  "name": "revizor",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -6671,6 +6671,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -10484,6 +10485,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10508,6 +10510,7 @@
       "version": "7.43.9",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.9.tgz",
       "integrity": "sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==",
+      "dev": true,
       "engines": {
         "node": ">=12.22.0"
       },
@@ -12142,6 +12145,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "node_modules/utility-types": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
+      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -12624,7 +12635,8 @@
       "name": "@astral/validations",
       "version": "3.0.0",
       "dependencies": {
-        "is-plain-obj": "^4.1.0"
+        "is-plain-obj": "^4.1.0",
+        "utility-types": "^3.10.0"
       }
     },
     "package/node_modules/is-plain-obj": {
@@ -12754,8 +12766,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/@astral/prettier-config/-/prettier-config-1.6.2.tgz",
       "integrity": "sha512-taJ+suUVpjp2NUSkmY6Qdoi9ZcQpEMDA1+GOZcpbR+FiTagGJcKrg6OcczVzhcdKAgTN/vFF7FPLgmOSnISCDQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@astral/PRLinter": {
       "version": "file:PRLinter",
@@ -12770,7 +12781,8 @@
     "@astral/validations": {
       "version": "file:package",
       "requires": {
-        "is-plain-obj": "^4.1.0"
+        "is-plain-obj": "^4.1.0",
+        "utility-types": "^3.10.0"
       },
       "dependencies": {
         "is-plain-obj": {
@@ -13616,8 +13628,7 @@
     "@hookform/resolvers": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.1.0.tgz",
-      "integrity": "sha512-z0A8K+Nxq+f83Whm/ajlwE6VtQlp/yPHZnXw7XWVPIGm1Vx0QV8KThU3BpbBRfAZ7/dYqCKKBNnQh85BkmBKkA==",
-      "requires": {}
+      "integrity": "sha512-z0A8K+Nxq+f83Whm/ajlwE6VtQlp/yPHZnXw7XWVPIGm1Vx0QV8KThU3BpbBRfAZ7/dYqCKKBNnQh85BkmBKkA=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -13810,8 +13821,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "7.1.0",
@@ -14115,8 +14125,7 @@
       "version": "14.4.3",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
       "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -14528,8 +14537,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -14988,8 +14996,7 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/commitlint-plugin-function-rules/-/commitlint-plugin-function-rules-1.7.1.tgz",
       "integrity": "sha512-hGLShcCM3my+q3unMoznSfV23JmpJ/R8aHQ5KGzxVwv3HFpDS4cFWraCdBRAkMbL1UzUrVOEutG4EDur5S7AsA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "compare-func": {
       "version": "2.0.0",
@@ -15196,8 +15203,7 @@
     "cosmiconfig-typescript-loader": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.3.0.tgz",
-      "integrity": "sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==",
-      "requires": {}
+      "integrity": "sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q=="
     },
     "create-require": {
       "version": "1.1.1",
@@ -15817,8 +15823,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.7",
@@ -15992,8 +15997,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
       "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -17589,6 +17593,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -17674,8 +17679,7 @@
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.10.0.tgz",
           "integrity": "sha512-hmAPf1datm+gt3c2mvu0sJyhFy6lTkIGf0GzyaZWxRLnabQfPUqg6tF95RPg6sLxKI7nFLGdFxBcf2/7+GXI+A==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -20269,6 +20273,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -20287,7 +20292,7 @@
       "version": "7.43.9",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.9.tgz",
       "integrity": "sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==",
-      "requires": {}
+      "dev": true
     },
     "react-is": {
       "version": "16.13.1",
@@ -21524,6 +21529,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "utility-types": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
+      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg=="
+    },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -21737,8 +21747,7 @@
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "4.0.0",

--- a/package/package.json
+++ b/package/package.json
@@ -13,6 +13,7 @@
     "lint:all": "eslint \"**/*.{ts,tsx}\" --fix --quiet"
   },
   "dependencies": {
-    "is-plain-obj": "^4.1.0"
+    "is-plain-obj": "^4.1.0",
+    "utility-types": "^3.10.0"
   }
 }

--- a/package/src/array/array.ts
+++ b/package/src/array/array.ts
@@ -18,7 +18,7 @@ import { ARRAY_TYPE_ERROR_INFO } from './constants';
 export const array = <TItem extends ValidationTypes, TValues = unknown>(
   ...rules: ValidationRule<Array<TItem>, TValues>[]
 ) =>
-  createGuard<Array<unknown>, TValues>((value, ctx, { typeErrorMessage }) => {
+  createGuard<TValues>((value, ctx, { typeErrorMessage }) => {
     if (!Array.isArray(value)) {
       return ctx.createError({
         ...ARRAY_TYPE_ERROR_INFO,

--- a/package/src/boolean/boolean.ts
+++ b/package/src/boolean/boolean.ts
@@ -16,7 +16,7 @@ import { BOOLEAN_TYPE_ERROR_INFO } from './constants';
 export const boolean = <TValues>(
   ...rules: ValidationRule<boolean, TValues>[]
 ) =>
-  createGuard<boolean, TValues>((value, ctx, { typeErrorMessage }) => {
+  createGuard<TValues>((value, ctx, { typeErrorMessage }) => {
     if (typeof value !== 'boolean') {
       return ctx.createError({
         ...BOOLEAN_TYPE_ERROR_INFO,

--- a/package/src/core/context/createContext/createContext.ts
+++ b/package/src/core/context/createContext/createContext.ts
@@ -1,3 +1,5 @@
+import { DeepPartial } from 'utility-types';
+
 import { ValidationContext } from '../types';
 import { createSimpleError } from '../../errors';
 import { ValidationTypes } from '../../types';
@@ -26,7 +28,7 @@ export function createContext<Value extends ValidationTypes, Values>(
 
   return {
     global: {
-      values: value,
+      values: value as DeepPartial<Value | Values>,
       overrides: {
         objectIsPartial: false,
       },

--- a/package/src/core/context/types.ts
+++ b/package/src/core/context/types.ts
@@ -1,27 +1,29 @@
+import { DeepPartial, DeepReadonly } from 'utility-types';
+
 import { createSimpleError } from '../errors';
 
 /**
  * @description Контекст, который доступен в каждом правиле
  */
-export type ValidationContext<TValues> = Readonly<{
+export type ValidationContext<TValues> = DeepReadonly<{
   /**
    * @description Глобальные значения, идущие от самого верхнего правила к самому нижнему
    */
-  global: Readonly<{
+  global: {
     /**
      * @description Значения, которые валидируется guard самого высоко порядка
      */
-    values: TValues;
+    values: DeepPartial<TValues>;
     /**
      * @description Глобальные переопределения (сквозные для всех правил)
      */
-    overrides: Readonly<{
+    overrides: {
       /**
        * @description Делает для всех объектов в схеме все свойства необязательными
        */
       objectIsPartial: boolean;
-    }>;
-  }>;
+    };
+  };
   /**
    * @description Фабрика ошибок. Возвращает новую ошибку валидации
    */

--- a/package/src/core/guard/createGuard/createGuard.test.ts
+++ b/package/src/core/guard/createGuard/createGuard.test.ts
@@ -7,7 +7,7 @@ describe('createGuard', () => {
   it('Создает guard, который возвращает ошибку', () => {
     const errorCode = createErrorCode('error');
 
-    const guard = createGuard<string, string>((_, ctx) => {
+    const guard = createGuard<string>((_, ctx) => {
       return ctx.createError({ message: 'myerror', code: errorCode });
     });
 
@@ -18,7 +18,7 @@ describe('createGuard', () => {
   });
 
   it('По-дефолту проверяет правило на required', () => {
-    const guard = createGuard<string, string>(() => undefined);
+    const guard = createGuard<string>(() => undefined);
 
     const error = guard(undefined);
 
@@ -26,7 +26,7 @@ describe('createGuard', () => {
   });
 
   it('guard.define: создает копию guard', () => {
-    const guard = createGuard<string, string>(() => undefined);
+    const guard = createGuard<string>(() => undefined);
 
     const error = guard.define({})('value');
 
@@ -34,7 +34,7 @@ describe('createGuard', () => {
   });
 
   it('guard.define:requiredErrorMessage: переопределяет message для required', () => {
-    const guard = createGuard<string, string>(() => undefined);
+    const guard = createGuard<string>(() => undefined);
 
     const error = guard.define({ requiredErrorMessage: 'custom message' })(
       undefined,
@@ -44,7 +44,7 @@ describe('createGuard', () => {
   });
 
   it('guard.define:isOptional=true: выключает required', () => {
-    const guard = createGuard<string, string>(() => undefined);
+    const guard = createGuard<string>(() => undefined);
 
     const error = guard.define({ isOptional: true })(undefined);
 
@@ -54,7 +54,7 @@ describe('createGuard', () => {
   it('guard.define:isOptional=true: если required не вернул ошибку, то пропускает валидацию дальше', () => {
     const errorCode = createErrorCode('error');
 
-    const guard = createGuard<string, string>((_, ctx) =>
+    const guard = createGuard<string>((_, ctx) =>
       ctx.createError({ message: '', code: errorCode }),
     );
 
@@ -64,7 +64,7 @@ describe('createGuard', () => {
   });
 
   it('Создает новый контекст, если его не было', () => {
-    const guard = createGuard<string, string>((_, ctx) => {
+    const guard = createGuard<string>((_, ctx) => {
       expect(ctx.global.values).toBe('');
 
       return undefined;

--- a/package/src/date/date.ts
+++ b/package/src/date/date.ts
@@ -20,7 +20,7 @@ type AdditionalDefOptions = {
  * ```
  */
 export const date = <TValues>(...rules: ValidationRule<Date, TValues>[]) =>
-  createGuard<Date, TValues, AdditionalDefOptions>(
+  createGuard<TValues, AdditionalDefOptions>(
     (value, ctx, { typeErrorMessage, invalidDateErrorMessage }) => {
       if (!(value instanceof Date)) {
         return ctx.createError({

--- a/package/src/deepPartial/deepPartial.ts
+++ b/package/src/deepPartial/deepPartial.ts
@@ -19,7 +19,7 @@ import { Guard, createRule } from '../core';
  *     const result = validate({ info: { info: {} } });
  * ```
  */
-export const deepPartial = <TValues>(guard: Guard<unknown, TValues>) =>
+export const deepPartial = <TValues>(guard: Guard<TValues>) =>
   createRule<unknown, TValues>((value, prevCtx) =>
     guard(value, {
       ...prevCtx,

--- a/package/src/number/number.ts
+++ b/package/src/number/number.ts
@@ -24,7 +24,7 @@ type AdditionalDefOptions = {
  * ```
  */
 export const number = <TValues>(...rules: ValidationRule<number, TValues>[]) =>
-  createGuard<number, TValues, AdditionalDefOptions>(
+  createGuard<TValues, AdditionalDefOptions>(
     (
       value,
       ctx,

--- a/package/src/object/object.test.ts
+++ b/package/src/object/object.test.ts
@@ -6,6 +6,8 @@ import {
   createSimpleError,
 } from '../core';
 import { string } from '../string';
+import { number } from '../number';
+import { when } from '../when';
 
 import { object } from './object';
 import { OBJECT_TYPE_ERROR_INFO } from './constants';
@@ -72,9 +74,21 @@ describe('object', () => {
   });
 
   it('Генерирует ошибку для object', () => {
-    const validate = object<{ name: string; surname: string }>({
-      name: string(),
-      surname: string(),
+    type V = { name: string; surname: string; org: Org };
+    type Org = { info: OrgInfo };
+    type OrgInfo = { data: string };
+
+    const orgInfo = <TV>() =>
+      object<OrgInfo, TV>({ data: (_, ctx) => ctx.global.values });
+
+    const org = <TV>() => object<Org, TV>({ info: orgInfo() });
+
+    const validate = object<V, V>({
+      name: number(),
+      surname: when({
+        is: (value, ctx) => Boolean(ctx.global.values.org?.info),
+      }),
+      org: object({ info: orgInfo() }),
     });
 
     const expectError = createErrorMap({

--- a/package/src/object/object.test.ts
+++ b/package/src/object/object.test.ts
@@ -6,8 +6,7 @@ import {
   createSimpleError,
 } from '../core';
 import { string } from '../string';
-import { number } from '../number';
-import { when } from '../when';
+import { optional } from '../../lib';
 
 import { object } from './object';
 import { OBJECT_TYPE_ERROR_INFO } from './constants';
@@ -74,21 +73,9 @@ describe('object', () => {
   });
 
   it('Генерирует ошибку для object', () => {
-    type V = { name: string; surname: string; org: Org };
-    type Org = { info: OrgInfo };
-    type OrgInfo = { data: string };
-
-    const orgInfo = <TV>() =>
-      object<OrgInfo, TV>({ data: (_, ctx) => ctx.global.values });
-
-    const org = <TV>() => object<Org, TV>({ info: orgInfo() });
-
-    const validate = object<V, V>({
-      name: number(),
-      surname: when({
-        is: (value, ctx) => Boolean(ctx.global.values.org?.info),
-      }),
-      org: object({ info: orgInfo() }),
+    const validate = object<{ name: string; surname: string }>({
+      name: string(),
+      surname: optional(string()),
     });
 
     const expectError = createErrorMap({

--- a/package/src/object/object.ts
+++ b/package/src/object/object.ts
@@ -33,11 +33,6 @@ type AdditionalDefOptions = {
 };
 
 /**
- * @description Тип, который необходим для того, чтобы object невозможно было использовать без использования generic
- */
-type NeverSchema = Record<'__never', never>;
-
-/**
  * @description Возможные значения, принимаемые схемой
  */
 export type SchemaValue<TValue, TValues> =
@@ -76,7 +71,7 @@ export type Schema<
  * ```
  */
 export const object = <
-  Value extends Record<string, unknown> = NeverSchema,
+  Value extends Record<string, unknown>,
   TValues = unknown,
 >(
   schema: Schema<Value, TValues>,

--- a/package/src/object/object.ts
+++ b/package/src/object/object.ts
@@ -70,7 +70,10 @@ export type Schema<
  * });
  * ```
  */
-export const object = <Value extends Record<string, unknown>, TValues>(
+export const object = <
+  Value extends Record<string, unknown>,
+  TValues = unknown,
+>(
   schema: Schema<Value, TValues>,
 ) =>
   createGuard<TValues, AdditionalDefOptions>(

--- a/package/src/optional/optional.ts
+++ b/package/src/optional/optional.ts
@@ -1,21 +1,9 @@
-import { Guard, ValidationTypes } from '../core';
-import { string } from '../string';
+import { Guard } from '../core';
 
 /**
  * @description Выключает проверку на required в guard
  * @param guard - правило, проверяющее тип значения
  * @example object({ name: optional(string(min(22))) })
  */
-export const optional = <ValidationType extends ValidationTypes, TValues>(
-  guard: Guard<ValidationType, TValues>,
-) => guard.define({ isOptional: true });
-
-const validateCustomString = string().define({
-  typeErrorMessage: 'Только строка',
-  requiredErrorMessage: 'Не может быть пустым',
-});
-
-// { message: 'Не может быть пустым' }
-validateCustomString(undefined);
-// { message: 'Только строка' }
-validateCustomString(20);
+export const optional = <TValues>(guard: Guard<TValues>) =>
+  guard.define({ isOptional: true });

--- a/package/src/string/string.ts
+++ b/package/src/string/string.ts
@@ -3,7 +3,7 @@ import { ValidationRule, compose, createGuard } from '../core';
 import { STRING_TYPE_ERROR_INFO } from './constants';
 
 export const string = <TValues>(...rules: ValidationRule<string, TValues>[]) =>
-  createGuard<string, TValues>((value, ctx, { typeErrorMessage }) => {
+  createGuard<TValues>((value, ctx, { typeErrorMessage }) => {
     if (typeof value !== 'string') {
       return ctx.createError({
         ...STRING_TYPE_ERROR_INFO,

--- a/package/src/when/when.test.ts
+++ b/package/src/when/when.test.ts
@@ -38,7 +38,7 @@ describe('when', () => {
 
     const validate = object<Values, Values>({
       name: when({
-        is: (_, ctx) => ctx.global.values.isAgree,
+        is: (_, ctx) => Boolean(ctx.global.values.isAgree),
         then: string(),
         otherwise: any(),
       }),


### PR DESCRIPTION
# Чеклист

- [x] Написать тесты
- [x] Описать jsdoc
- [x] Обновить документацию в README.md

# Изменения

- ```ctx.global.values``` стал DeepPartial
- для guard убран лишний параметр в generic, который ничего не делал
- для object убрано отображение ошибки, если в generic ничего не прокинуто (ошибка была не явная)
- guard и rules, используемые в object теперь автоматически вычисляют тип ```ctx.global.values```